### PR TITLE
Use name with namepspace for project name

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -104,7 +104,7 @@ angular.module('app', ['config.app', 'emojify', '720kb.tooltips'])
         gitlabService.getMergeRequests(project.id).then(function (mergeRequests) {
           mergeRequests.forEach(function (mergeRequest) {
             mergeRequest.project = {};
-            mergeRequest.project.name = project.name;
+            mergeRequest.project.name = project.name_with_namespace;
             mergeRequest.project.web_url = project.web_url;
             mergeRequest.web_url = project.web_url + '/merge_requests/' + mergeRequest.iid;
 


### PR DESCRIPTION
Project can have the same name, example : project _Documentation_ is present in multiples namespaces.
