### PR TITLE
:bug: Make http call to get user only if url and token are present

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -42,12 +42,22 @@ angular.module('app', ['emojify', '720kb.tooltips', 'ngRoute', 'LocalStorageModu
   }
 
   gitLabManager.getUser = function() {
-    return $http({
-      url: gitLabManager.getUrl() + '/api/v3/user',
-      headers:  {'PRIVATE-TOKEN': this.getPrivateToken()}
-    }).then(function(response) {
-      return response.data;
-    });
+    var deferred = $q.defer();
+
+    if (!gitLabManager.isAuthentificated()) {
+      deferred.reject("Url and/or private token are missing");
+    } else {
+      $http({
+        url: gitLabManager.getUrl() + '/api/v3/user',
+        headers:  {'PRIVATE-TOKEN': this.getPrivateToken()}
+      }).then(function(response) {
+        deferred.resolve(response.data);
+      }, function(msg) {
+        deferred.reject(msg);
+      });
+    }
+
+    return deferred.promise;
   }
 
   gitLabManager.isAuthentificated = function() {


### PR DESCRIPTION
#### Description

The current version makes an http call to get the user in all cases even if the url and token are not present.

What causes this kind of requests  : 

<img width="569" alt="capture d ecran 2016-08-04 a 18 45 35" src="https://cloud.githubusercontent.com/assets/523981/17410403/d0fcd902-5a73-11e6-90c9-ce2cbae07c18.png">

I added a check on url and token before making the request.
#### Resume
- Bug fix: yes
- New feature: no
- Fixed tickets: -
