### PR TITLE
Rename isAuthentificated to hasCredentials

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -44,7 +44,7 @@ angular.module('app', ['emojify', '720kb.tooltips', 'ngRoute', 'LocalStorageModu
   gitLabManager.getUser = function() {
     var deferred = $q.defer();
 
-    if (!gitLabManager.isAuthentificated()) {
+    if (!gitLabManager.hasCredentials()) {
       deferred.reject("Url and/or private token are missing");
     } else {
       $http({
@@ -60,7 +60,7 @@ angular.module('app', ['emojify', '720kb.tooltips', 'ngRoute', 'LocalStorageModu
     return deferred.promise;
   }
 
-  gitLabManager.isAuthentificated = function() {
+  gitLabManager.hasCredentials = function() {
     return gitLabManager.getUrl() && gitLabManager.getPrivateToken();
   }
 
@@ -297,7 +297,7 @@ angular.module('app', ['emojify', '720kb.tooltips', 'ngRoute', 'LocalStorageModu
 
   // This events gets triggered on refresh or URL change
   $rootScope.$on('$locationChangeStart', function() {
-    if (!gitLabManager.isAuthentificated()) {
+    if (!gitLabManager.hasCredentials()) {
       $location.path('/settings');
     }
   });


### PR DESCRIPTION
#### Description

Rename _isAuthentificated_ method of gitlabManager to _hasCredentials_to avoid misunderstandings.
#### Resume
- Bug fix: no
- New feature: no
- Fixed tickets: #86
