### PR TITLE
Center content in dashboard table

### DIFF
--- a/app/assets/dashboard.html
+++ b/app/assets/dashboard.html
@@ -8,8 +8,8 @@
       <th>Branch</th>
       <th ng-bind-html="':+1:'|emojify"></th>
       <th ng-bind-html="':-1:'|emojify"></th>
-      <th>Have I voted?</th>
-      <th>CI</th>
+      <th class="text-center">Have I voted?</th>
+      <th class="text-center">CI</th>
     </tr>
   </thead>
   <tbody>
@@ -17,32 +17,32 @@
       <td><time tooltips tooltip-template="{{ mergeRequest.lastActivity | date: 'short' }}" tooltip-size="small" tooltip-smart="true" am-time-ago="mergeRequest.lastActivity"></time></td>
       <td><a href="{{ mergeRequest.project.web_url }}" target="_blank">{{ mergeRequest.project.name }}</a></td>
       <td><a href="{{ mergeRequest.web_url }}" target="_blank" ng-bind-html="mergeRequest.title|emojify"></a></td>
-      <td>
+      <td class="text-center">
           <span tooltips tooltip-template="{{ mergeRequest.author.name }}" tooltip-size="small">
               <img class="author" ng-src="{{ mergeRequest.author.avatar_url }}" width="35px" alt="{{ mergeRequest.author.name }}"></img>
           </span>
       </td>
       <td>{{ mergeRequest.source_branch }} &#8680; {{ mergeRequest.target_branch }}</td>
-      <td>
+      <td class="text-center">
           <span tooltips tooltip-template="{{ mergeRequest.upvoters.join(', ') }}" tooltip-size="small" tooltip-hidden="{{ mergeRequest.upvoters.length == 0 }}">
               <span ng-class="{'success': mergeRequest.upvotes > 0, 'alert': mergeRequest.upvotes == 0}" class="upvote badge">
                   {{ mergeRequest.upvotes }}
               </span>
           </span>
       </td>
-      <td>
+      <td class="text-center">
           <span tooltips tooltip-template="{{ mergeRequest.downvoters.join(', ') }}" tooltip-size="small" tooltip-hidden="{{ mergeRequest.downvoters.length == 0 }}">
               <span ng-class="{'success': mergeRequest.downvotes == 0, 'alert': mergeRequest.downvotes > 0}" class="downvote badge">
                   {{ mergeRequest.downvotes }}
               </span>
           </span>
       </td>
-      <td>
+      <td class="text-center">
         <span ng-if="mergeRequest.i_have_voted === 0">-</span>
         <span ng-if="mergeRequest.i_have_voted === 1" ng-bind-html="':+1:'|emojify"></span>
         <span ng-if="mergeRequest.i_have_voted === -1" ng-bind-html="':-1:'|emojify"></span>
       </td>
-      <td>
+      <td class="text-center">
         <a href="{{ mergeRequest.ci.url }}" target="_blank" ng-if="mergeRequest.ci.status" ng-class="{'success': mergeRequest.ci.status == 'success', 'alert': mergeRequest.ci.status == 'failed'}" class="button tiny">{{ mergeRequest.ci.status }}</a>
       </td>
     </tr>


### PR DESCRIPTION
#### Description

Center content of several columns (CI, I have voted ?, author) in the dashboard table.

Before : 

<img width="661" alt="capture d ecran 2016-08-05 a 11 02 47" src="https://cloud.githubusercontent.com/assets/523981/17431859/59d0bd4c-5afc-11e6-9bd4-666503556255.png">

After :

<img width="658" alt="capture d ecran 2016-08-05 a 11 02 40" src="https://cloud.githubusercontent.com/assets/523981/17431862/60b1bee0-5afc-11e6-9129-b1f542922ab8.png">
#### Resume
- Bug fix: no
- New feature: yes
- Fixed tickets: -
