### PR TITLE
:bug: Get labels only for projects with MRs

### DIFF
--- a/app/services.js
+++ b/app/services.js
@@ -224,6 +224,10 @@ angular.module('app')
   };
 
   var formatLabelsForMergeRequests = function(project, mergeRequests) {
+    if (mergeRequests.length === 0) {
+      return;
+    }
+
     var url = '/projects/' + project.id + '/labels';
     return request(url).then(function(response) {
         var labels = {};


### PR DESCRIPTION
#### Description

Get labels of a project only when the project has active merge requests.

Before : 209 requests
After : 129 requests
#### Resume
- Bug fix: yes
- New feature: no
- Fixed tickets: -
