### PR TITLE
Remove outdated part of the readme about first connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ $ npm run serve
 
 Then open `http://localhost:3000` in your browser.
 
-At the first connection, you must configure :
-
-* **refreshInterval** : time in seconds between 2 dashboard updates
-* **apiUrl** : url of your GitLab API
-* **token** : private token for API calls
-
 ## Credits
 
 Developed by the SI Team of [Hexanet](http://www.hexanet.fr/).


### PR DESCRIPTION
#### Description

This part of the readme is now partially wrong (api url instead of gitlab instance url, etc) and I think this is not needed  anymore since we do not have any configuration file.

If you are not ok with this, I could just fix the outdated part of the readme. 
 