### PR TITLE
:bug: Fix refresh of merge requests

### DIFF
--- a/app/services.js
+++ b/app/services.js
@@ -176,7 +176,7 @@ angular.module('app')
   };
 
   var getMergeRequest = function(projectId, mergeRequestId) {
-    var url = '/projects/' + projectId + '/merge_request/' + mergeRequestId;
+    var url = '/projects/' + projectId + '/merge_requests/' + mergeRequestId;
     return request(url).then(function(response) {
       return response.data;
     });


### PR DESCRIPTION
#### Description

The last MR #113 broke the refresh of the merge requests because the API url change:

From https://docs.gitlab.com/ee/api/v3_to_v4.html ->

The endpoint url change -> Endpoints under GET /projects/merge_request/:id have been removed (use: GET /projects/merge_requests/:id)


#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #114 
