### PR TITLE
Fix refresh of MRs

### DIFF
--- a/app/services.js
+++ b/app/services.js
@@ -274,7 +274,7 @@ angular.module('app')
       projects.forEach(function (project) {
         getMergeRequests(project).then(function (mergeRequests) {
           mergeRequests.forEach(function (mergeRequest) {
-            MergeRequestFetcher.mergeRequests[mergeRequest.id] = mergeRequest;
+            MergeRequestFetcher.mergeRequests[mergeRequest.iid] = mergeRequest;
             updateFavico();
           });
         });


### PR DESCRIPTION
#### Description

Use iid to get merge request instead of id:

> API uses merge request IIDs (internal ID, as in the web UI) rather than IDs. This affects the merge requests, award emoji, todos, and time tracking APIs.

https://docs.gitlab.com/ee/api/v3_to_v4.html

I do some tests this time and it's ok.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #114 
