### PR TITLE
Remove deprecated brunch plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "private": true,
   "licence": "MIT",
   "devDependencies": {
+    "brunch": "^2.10.0",
     "assetsmanager-brunch": "^1.8.1",
-    "brunch": "^2.9.1",
-    "css-brunch": "^2.6.1",
-    "javascript-brunch": "^2.0.0",
     "sass-brunch": "^2.10.0",
     "serve": "^1.4.0"
   },


### PR DESCRIPTION
#### Description

Since the version `2.10` of brunch, the javascript and css plugins are deprecated. Both of them are built-in possibilities of Brunch.

See https://github.com/brunch/javascript-brunch and https://github.com/brunch/css-brunch for more informations. 
