### PR TITLE
Use the new /merge_resquests API

### DIFF
--- a/app/assets/dashboard.html
+++ b/app/assets/dashboard.html
@@ -15,7 +15,7 @@
   </thead>
   <tbody>
     <tr ng-repeat="mergeRequest in vm.mergeRequests">
-      <td><time tooltips tooltip-template="{{ mergeRequest.lastActivity | date: 'short' }}" tooltip-size="small" tooltip-smart="true" am-time-ago="mergeRequest.lastActivity"></time></td>
+      <td><time tooltips tooltip-template="{{ mergeRequest.updated_at | date: 'short' }}" tooltip-size="small" tooltip-smart="true" am-time-ago="mergeRequest.updated_at"></time></td>
       <td><a href="{{ mergeRequest.project.web_url }}" target="_blank">{{ mergeRequest.project.name }}</a></td>
       <td><a href="{{ mergeRequest.web_url }}" target="_blank" ng-bind-html="mergeRequest.title|emojify"></a></td>
       <td class="text-center">
@@ -26,7 +26,7 @@
       <td ng-if="vm.displayBranchColumn">{{ mergeRequest.source_branch }} &#8680; {{ mergeRequest.target_branch }}</td>
       <td ng-if="vm.displayLabelsColumn">
         <ul class="menu simple">
-          <li ng-repeat="label in mergeRequest.labels">
+          <li ng-repeat="label in mergeRequest.formatted_labels">
             <span style="background-color: {{ label.color }}" class="label tiny" tooltips tooltip-template="{{ label.description }}" tooltip-size="small">{{ label.name }}</span>
           </li>
         </ul>


### PR DESCRIPTION
#### Description

Reduce API calls by using the new /merge_requests API. The API returns all opened merge requests  which the user has access. 

Before: 172 requests

<img width="111" alt="capture d ecran 2017-08-27 a 12 52 18" src="https://user-images.githubusercontent.com/523981/29749204-010f1990-8b27-11e7-86ff-5cd834033d14.png">

Now: 24 requests

<img width="101" alt="capture d ecran 2017-08-27 a 12 52 36" src="https://user-images.githubusercontent.com/523981/29749207-0cec774e-8b27-11e7-814b-fc9a3a8a73a5.png">

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: #74 
