### PR TITLE
Fix link to internal route after angularjs update

### DIFF
--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -11,13 +11,13 @@
       <div class="top-bar-left">
           <ul class="dropdown menu" data-dropdown-menu>
               <li class="menu-text title">
-                  <a href="#/"><img class="logo" src="logo.png" /> Merge Requests CI</a>
+                  <a href="#!/"><img class="logo" src="logo.png" /> Merge Requests CI</a>
               </li>
           </ul>
       </div>
       <div class="top-bar-right">
           <ul class="menu">
-              <li><a href="#/settings">Settings</a></li>
+              <li><a href="#!/settings">Settings</a></li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
#### Description

After the last PR (#148) links in the app no longer work.

With Angular > 1.6 : link must use `#!/` instead of `#/`.

See https://stackoverflow.com/questions/41211875/angularjs-1-6-0-latest-now-routes-not-working

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: -
